### PR TITLE
Drops deprecated --containerd from 1.19

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -100,7 +100,6 @@ func startKubelet(cfg *config.Agent) error {
 	if cfg.RuntimeSocket != "" {
 		argsMap["container-runtime"] = "remote"
 		argsMap["container-runtime-endpoint"] = cfg.RuntimeSocket
-		argsMap["containerd"] = cfg.RuntimeSocket
 		argsMap["serialize-image-pulls"] = "false"
 	} else if cfg.PauseImage != "" {
 		argsMap["pod-infra-container-image"] = cfg.PauseImage


### PR DESCRIPTION
Testing if we can get containers metrics back by dropping --containerd flag from kubelet
